### PR TITLE
Update follow controller

### DIFF
--- a/app/controllers/api/follows_controller.rb
+++ b/app/controllers/api/follows_controller.rb
@@ -1,9 +1,8 @@
 class Api::FollowsController < ApplicationController
 
   def create
+    debugger
     @follow = Follow.new(follow_params)
-    #will we be able to receive current_user the same way we used to be able to?
-    @follow.follower_id = current_user.id
     if @follow.save
       render json: @follow.leader
     else
@@ -18,7 +17,7 @@ class Api::FollowsController < ApplicationController
   end
 
   def follow_params
-    params.require(:follow).permit(:leader_id)
+    params.require(:follow).permit(:leader_id, :follower_id)
   end
 
 end

--- a/app/controllers/api/follows_controller.rb
+++ b/app/controllers/api/follows_controller.rb
@@ -3,6 +3,8 @@ class Api::FollowsController < ApplicationController
   def create
     @follow = Follow.new(follow_params)
     if @follow.save
+      # returns the id of the leader to be added to the current
+      # user's leaders array
       render json: @follow.leader_id
     else
       render json: @follow.errors.full_messages, status: 422
@@ -12,6 +14,8 @@ class Api::FollowsController < ApplicationController
   def destroy
     @follow = Follow.find_by(follow_params)
     @follow.destroy
+    # returns the id of the leader to be removed from the current
+    # user's leaders array
     render json: @follow.leader_id
   end
 

--- a/app/controllers/api/follows_controller.rb
+++ b/app/controllers/api/follows_controller.rb
@@ -11,7 +11,7 @@ class Api::FollowsController < ApplicationController
   end
 
   def destroy
-    @follow = Follow.find_by(params[:id])
+    @follow = Follow.find_by(follow_params)
     @follow.destroy
     render json: @follow
   end

--- a/app/controllers/api/follows_controller.rb
+++ b/app/controllers/api/follows_controller.rb
@@ -12,7 +12,7 @@ class Api::FollowsController < ApplicationController
   def destroy
     @follow = Follow.find_by(follow_params)
     @follow.destroy
-    render json: @follow
+    render json: @follow.leader_id
   end
 
   def follow_params

--- a/app/controllers/api/follows_controller.rb
+++ b/app/controllers/api/follows_controller.rb
@@ -1,10 +1,9 @@
 class Api::FollowsController < ApplicationController
 
   def create
-    debugger
     @follow = Follow.new(follow_params)
     if @follow.save
-      render json: @follow.leader
+      render json: @follow.leader_id
     else
       render json: @follow.errors.full_messages, status: 422
     end


### PR DESCRIPTION
Update follow controller to receive follow params for both create follow and destroy follow methods:

this way, when we create a follow we send {follower_id: this.props.currentUser.id, leader_id: this.props.post.author.id} to ...api/follows

AND when we destroy a follow we send that same follow object.
!! normally the destroy method of a controller is linked to a route something like this: api/follows/:id
it needs that wild card at the end to hit the destroy method.
since we're destroying based on the follower_id and the leader_id, we don't have an :id wildcard (that's the id of the follow row in the follows table)
that being said, it still needs that wildcard to hit the correct route so in the fetchDestroyFollow api_util, it goes to ...api/follows/1

other changes: both methods on the follows controller return rendered json of the leader id. just the number